### PR TITLE
ci: update golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
           cache: false # see actions/setup-go#368
 
       - uses: actions/checkout@v4
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.61.0
+          version: v2.1.6
           skip-cache: true
           args: --timeout=5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,32 +1,47 @@
+version: "2"
 linters:
   enable:
     - copyloopvar
-    - gofmt
-    - goimports
+    - dupword
     - gosec
+    - govet
     - ineffassign
     - misspell
     - nolintlint
     - revive
     - staticcheck
-    - tenv # Detects using os.Setenv instead of t.Setenv since Go 1.17
     - unconvert
     - unused
-    - govet
-    - dupword # Checks for duplicate words in the source code
   disable:
     - errcheck
-
-run:
-  timeout: 5m
-
-issues:
-  exclude-dirs:
-    - api
-    - cluster
-    - design
-    - docs
-    - docs/man
-    - releases
-    - reports
-    - test # e2e scripts
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - api
+      - cluster
+      - design
+      - docs
+      - docs/man
+      - releases
+      - reports
+      - test
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - api
+      - cluster
+      - design
+      - docs
+      - docs/man
+      - releases
+      - reports
+      - test


### PR DESCRIPTION
This change updates golangci-lint to v2.1.6.

For the configuration updates, I ran `golangci-lint migrate` and added back a few linters that had been removed by default.