### PR TITLE
Update project-checks to v1.2.2 to unblock CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           path: src/github.com/containerd/log
           fetch-depth: 25
 
-      - uses: containerd/project-checks@v1.1.0
+      - uses: containerd/project-checks@v1.2.2
         with:
           working-directory: src/github.com/containerd/log
           repo-access-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change updates containerd/project-checks to v1.2.2 which to unblock PRs.

This change also adds dependabot updates for GitHub Actions packages so it is trivial for these changes to come through automation. Note: containerd/log is a common library used by many projects so we intentionally do not want to add dependabot for Go build deps due to how Go's minimal version selection works.